### PR TITLE
Feature - useFetchPaginated hoook

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="ddf2d2a0-7c19-416e-90fe-91d8f5ee0b47" name="Changes" comment="Feature - useFetch hook">
+      <change afterPath="$PROJECT_DIR$/my-app/src/utils/useFetch.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/my-app/src/components/Pages/SearchPage.js" beforeDir="false" afterPath="$PROJECT_DIR$/my-app/src/components/Pages/SearchPage.js" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="main" />
+      </map>
+    </option>
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+    <option name="RESET_MODE" value="HARD" />
+  </component>
+  <component name="GitToolBoxStore">
+    <option name="projectConfigVersion" value="5" />
+    <option name="recentBranches">
+      <RecentBranches>
+        <option name="branchesForRepo">
+          <list>
+            <RecentBranchesForRepo>
+              <option name="branches">
+                <list>
+                  <RecentBranch>
+                    <option name="branchName" value="feature/usefetch-hook" />
+                    <option name="lastUsedInstant" value="1657461964" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="main" />
+                    <option name="lastUsedInstant" value="1657461929" />
+                  </RecentBranch>
+                </list>
+              </option>
+              <option name="repositoryRootUrl" value="file://$PROJECT_DIR$" />
+            </RecentBranchesForRepo>
+          </list>
+        </option>
+      </RecentBranches>
+    </option>
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "node.js.selected.package.tslint": "(autodetect)"
+  }
+}]]></component>
+  <component name="TaskManager">
+    <servers />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/my-app/src/components/Pages/ColorPage.js
+++ b/my-app/src/components/Pages/ColorPage.js
@@ -1,16 +1,11 @@
 import React from 'react';
-import { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { Text, Flex, Center, Button } from '@chakra-ui/react';
+import { useParams } from 'react-router-dom';
 
 import FeedGrid from '../shared/Feed/FeedGrid';
 import PaginationNav from '../shared/Feed/PaginationNav';
+import useFetchPaginated from '../../utils/useFetchPaginated';
 
 export default function ColorPage() {
-  const [data, setData] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
   const params = useParams();
 
   const apiURL = `https://api.feverdreams.app/rgb/${params.r}/${params.g}/${params.b}/${params.range}/${params.amount}/${params.page}`;
@@ -23,21 +18,7 @@ export default function ColorPage() {
     params.amount
   }/${parseInt(params.page) + 1}`;
 
-  useEffect(() => {
-    fetch(apiURL)
-      .then((response) => response.json())
-      .then((actualData) => {
-        setData(actualData);
-        setError(null);
-      })
-      .catch((err) => {
-        setError(err.message);
-        setData(null);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
-  }, [params.page]);
+  const { loading, data } = useFetchPaginated(apiURL, params);
 
   return (
     <>

--- a/my-app/src/components/Pages/PiecePage.js
+++ b/my-app/src/components/Pages/PiecePage.js
@@ -1,23 +1,22 @@
-import React from 'react';
-import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { ExternalLinkIcon } from '@chakra-ui/icons';
+import React, {useEffect, useState} from 'react';
+import {useParams} from 'react-router-dom';
+import {ExternalLinkIcon} from '@chakra-ui/icons';
 import {
-  Heading,
-  Link,
-  Image,
-  Text,
   Badge,
-  Stack,
-  Code,
   Button,
+  Code,
+  Heading,
   HStack,
-  VStack,
-  useClipboard,
+  Image,
+  Link,
   Skeleton,
+  Stack,
+  Text,
+  useClipboard,
+  VStack,
 } from '@chakra-ui/react';
-import { DreamAuthor } from '../shared/DreamAuthor';
-import { dt } from '../../utils/dateUtils';
+import {DreamAuthor} from '../shared/DreamAuthor';
+import {dt} from '../../utils/dateUtils';
 
 function PiecePage() {
   const IMAGE_HOST = 'https://images.feverdreams.app';
@@ -39,8 +38,7 @@ function PiecePage() {
 
     fetch(`https://api.feverdreams.app/job/${uuid}`)
       .then((response) => {
-        let obj = response.json();
-        return obj;
+        return response.json();
       })
       .then((actualData) => {
         actualData.dominant_color = actualData.dominant_color || [0, 0, 0];

--- a/my-app/src/components/Pages/RecentGalleryPage.js
+++ b/my-app/src/components/Pages/RecentGalleryPage.js
@@ -1,16 +1,11 @@
 import React from 'react';
-import { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { Text, Flex, Center, Button } from '@chakra-ui/react';
+import { useParams } from 'react-router-dom';
 
 import FeedGrid from '../shared/Feed/FeedGrid';
 import PaginationNav from '../shared/Feed/PaginationNav';
+import useFetchPaginated from '../../utils/useFetchPaginated';
 
 export default function RecentGalleryPage() {
-  const [data, setData] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
   const params = useParams();
 
   const apiURL = `https://api.feverdreams.app/recent/50/${params.page}`;
@@ -18,23 +13,7 @@ export default function RecentGalleryPage() {
   const prevURL = `/recent/${parseInt(params.page) - 1}`;
   const nextURL = `/recent/${parseInt(params.page) + 1}`;
 
-  useEffect(() => {
-    setLoading(true);
-
-    fetch(apiURL)
-      .then((response) => response.json())
-      .then((actualData) => {
-        setData(actualData);
-        setError(null);
-      })
-      .catch((err) => {
-        setError(err.message);
-        setData(null);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
-  }, [params.page]);
+  const { loading, data } = useFetchPaginated(apiURL, params);
 
   console.log('loading', loading);
 

--- a/my-app/src/components/Pages/SearchPage.js
+++ b/my-app/src/components/Pages/SearchPage.js
@@ -1,16 +1,11 @@
 import React from 'react';
-import { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import { Text, Flex, Center, Button } from '@chakra-ui/react';
+import { useParams } from 'react-router-dom';
 
 import FeedGrid from '../shared/Feed/FeedGrid';
 import PaginationNav from '../shared/Feed/PaginationNav';
+import useFetchPaginated from '../../utils/useFetchPaginated';
 
 export default function SearchPage() {
-  const [data, setData] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
   const params = useParams();
 
   const apiURL = `https://api.feverdreams.app/search/${params.regexp}/50/${params.page}`;
@@ -18,23 +13,7 @@ export default function SearchPage() {
   const prevURL = `/recent/${parseInt(params.page) - 1}`;
   const nextURL = `/recent/${parseInt(params.page) + 1}`;
 
-  useEffect(() => {
-    setLoading(true);
-
-    fetch(apiURL)
-      .then((response) => response.json())
-      .then((actualData) => {
-        setData(actualData);
-        setError(null);
-      })
-      .catch((err) => {
-        setError(err.message);
-        setData(null);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
-  }, [params.page]);
+  const { loading, data } = useFetchPaginated(apiURL, params);
 
   return (
     <>

--- a/my-app/src/utils/useFetchPaginated.js
+++ b/my-app/src/utils/useFetchPaginated.js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+function useFetchPaginated(apiURL, params) {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+
+    fetch(apiURL)
+      .then((response) => response.json())
+      .then((actualData) => {
+        setData(actualData);
+        setError(null);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setData(null);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [params.page, apiURL]);
+
+  return { error, data, loading };
+}
+
+useFetchPaginated.propTypes = {
+  apiURL: PropTypes.string,
+  params: PropTypes.shape({
+    page: PropTypes.number,
+  }),
+};
+
+export default useFetchPaginated;


### PR DESCRIPTION
This PR adds a custom hook to the project that helps reduce the amount of code duplication. The custom hook `useFetchPaginated` receives: 

- An URL to fetch as the first parameter
- A params object that includes the page to fetch. 

It returns: 
- loading: the current state of the request
- data: data from the API
- error: if something goes wrong, you can display a message to the user or show a tooltip.

This custom hook can be used when we want to fetch paginated results. Should not be used to fetch non-paginated pages. 