### PR TITLE
[Search] Add a 500ms to debounce search

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -19,6 +19,7 @@
         "algoliasearch": "^4.13.1",
         "formik": "^2.2.9",
         "framer-motion": "^6.3.11",
+        "lodash": "^4.17.21",
         "qs": "^6.11.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -14,6 +14,7 @@
     "algoliasearch": "^4.13.1",
     "formik": "^2.2.9",
     "framer-motion": "^6.3.11",
+    "lodash": "^4.17.21",
     "qs": "^6.11.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/my-app/src/components/shared/Nav/Nav.js
+++ b/my-app/src/components/shared/Nav/Nav.js
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-
+import { useEffect, useState, useRef } from 'react';
 import {
   Link as RouteLink,
   Link,
@@ -39,7 +38,7 @@ import {
   Configure,
 } from 'react-instantsearch-hooks-web';
 import { useSearchBox } from 'react-instantsearch-hooks-web';
-import qs from 'qs';
+import debounce from 'lodash.debounce';
 
 import { HamburgerIcon, CloseIcon, MoonIcon, SunIcon } from '@chakra-ui/icons';
 import { LoginButton } from './LoginButton';
@@ -85,6 +84,10 @@ const CustomSearchBox = (props) => {
     refine(searchParams.get('q'));
   }, []);
 
+  const debouncedSearch = useRef(
+    debounce((searchTerm) => refine(searchTerm), 700)
+  ).current;
+
   return (
     <>
       <Configure hitsPerPage={50} />
@@ -100,7 +103,7 @@ const CustomSearchBox = (props) => {
           value={searchParams.get('q') ?? ''}
           onChange={(e) => {
             // This updates the search term sent to Algolia / maintained in the InstantSearch context.
-            refine(e.target.value);
+            debouncedSearch(e.target.value);
 
             navigate(`/search?q=${encodeURIComponent(e.target.value)}`, {
               replace: true,

--- a/my-app/src/components/shared/Nav/Nav.js
+++ b/my-app/src/components/shared/Nav/Nav.js
@@ -85,7 +85,7 @@ const CustomSearchBox = (props) => {
   }, []);
 
   const debouncedSearch = useRef(
-    debounce((searchTerm) => refine(searchTerm), 700)
+    debounce((searchTerm) => refine(searchTerm), 500)
   ).current;
 
   return (


### PR DESCRIPTION
We are searching on every keystroke. This will be expensive AF. 

This introduces a 500ms debounce to search.