### PR TITLE
Fix pagination to 0

### DIFF
--- a/my-app/src/components/shared/Feed/PaginationNav.js
+++ b/my-app/src/components/shared/Feed/PaginationNav.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Text, Flex, Center, Button } from '@chakra-ui/react';
-import { Icon, ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
+import { ArrowBackIcon, ArrowForwardIcon } from '@chakra-ui/icons';
 
 /* Creates a back, forward, and page # button navigator. Some gallery views are paginated while others (e.g. random) are not */
-const PaginationNav = ({ pageNumber, prevURL, nextURL }) => (
-  <Center mt={4} mb={4} fontSize="lg">
+const PaginationNav = ({ pageNumber, prevURL, nextURL }) => {
+  const minPageToPaginate = pageNumber > 1;
+  const isPageButtonDisabled = parseInt(pageNumber) === 1
+
+  return <Center mt={4} mb={4} fontSize="lg">
     <Flex marginBottom={3} alignItems="center">
-      <Link to={prevURL}>
-        <Button variant="outline" colorScheme="blue">
+      <Link to={minPageToPaginate && prevURL}>
+        <Button variant="outline" colorScheme="blue" disabled={isPageButtonDisabled}>
           <ArrowBackIcon />
         </Button>
       </Link>
@@ -17,11 +20,11 @@ const PaginationNav = ({ pageNumber, prevURL, nextURL }) => (
       </Text>
       <Link to={nextURL}>
         <Button variant="outline" colorScheme="blue">
-          <ArrowForwardIcon />
+          <ArrowForwardIcon/>
         </Button>
       </Link>
     </Flex>
   </Center>
-);
+}
 
 export default PaginationNav;


### PR DESCRIPTION
This PR fixes a bug where a user is able to go to page 0 of the gallery, showing 0 results. 
The fix works in the following way: 
- User is on page 1? Disable previous page pagination
- User is on another page? Allow previous page pagination

<img width="944" alt="image" src="https://user-images.githubusercontent.com/13205128/179359084-c66d0c7e-4627-4247-ae90-f6a273e652f6.png">

<img width="949" alt="image" src="https://user-images.githubusercontent.com/13205128/179359104-5c7c6734-353a-47e5-8b39-eda55b08ef52.png">
